### PR TITLE
Additional output for service name and optional container name input.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [{
-    "name": "${var.name_prefix}",
+    "name": "${var.container_name == "" ? var.name_prefix : var.container_name}",
     "image": "${var.task_container_image}",
     "essential": true,
     "portMappings": [

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ data "null_data_source" "task_environment" {
 }
 
 resource "aws_ecs_task_definition" "task" {
+  id = "${var.name_prefix}"
   family                   = "${var.name_prefix}"
   execution_role_arn       = "${aws_iam_role.execution.arn}"
   network_mode             = "awsvpc"

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,6 @@ data "null_data_source" "task_environment" {
 }
 
 resource "aws_ecs_task_definition" "task" {
-  id = "${var.name_prefix}"
   family                   = "${var.name_prefix}"
   execution_role_arn       = "${aws_iam_role.execution.arn}"
   network_mode             = "awsvpc"

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_ecs_service" "service" {
   }
 
   load_balancer {
-    container_name   = "${var.name_prefix}"
+    container_name   = "${var.container_name == "" ? var.name_prefix : var.container_name}"
     container_port   = "${var.task_container_port}"
     target_group_arn = "${aws_lb_target_group.task.arn}"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "service_arn" {
 }
 
 output "service_name" {
-  description = "TThe name of the service."
+  description = "The name of the service."
   value       = "${aws_ecs_service.service.name}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,11 @@ output "service_arn" {
   value       = "${aws_ecs_service.service.id}"
 }
 
+output "service_name" {
+  description = "TThe name of the service."
+  value       = "${aws_ecs_service.service.name}"
+}
+
 output "target_group_arn" {
   description = "The ARN of the Target Group."
   value       = "${aws_lb_target_group.task.arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,11 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
+variable "container_name" {
+  description = "Optional name for the container. If not specified, name_prefix will be used. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
+  default = ""
+}
+
 variable "vpc_id" {
   description = "The VPC ID."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "name_prefix" {
 
 variable "container_name" {
   description = "Optional name for the container. If not specified, name_prefix will be used. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
-  default = ""
+  default     = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Added another output that allows us to refer to the service name from other resources. Specifically, we use this to add a subscription to the log group of the service for the a splunk/s3 log forwarder lambda.

Added an optional variable that allows specifying the container name of the service. This is very useful so that the container name can be fixed across services/environments. It is then straightforward to generate a imagedefinitions.json file after the docker image creation, so that one can use codepipeline to deploy the newly built image.