### PR TITLE
Outputs the service_name to use it in cloudwatch-logs-s3-forwarder

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,3 +25,8 @@ output "service_sg_id" {
   description = "The Amazon Resource Name (ARN) that identifies the service security group."
   value       = "${aws_security_group.ecs_service.id}"
 }
+
+output "service_name" {
+  description = "The name of the service."
+  value       = "${aws_ecs_service.service.name}"
+}


### PR DESCRIPTION
Added another output that allows us to refer to the service name from other resources. Specifically, we use this to add a subscription to the log group of the service for the a splunk/s3 log forwarder lambda.

part of Paul's PR - https://github.com/telia-oss/terraform-aws-ecs-fargate/pull/7