### PR TITLE
Output Target Group name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,6 +11,11 @@ output "target_group_arn" {
   value       = "${aws_lb_target_group.task.arn}"
 }
 
+output "target_group_name" {
+  description = "The Name of the Target Group."
+  value       = "${aws_lb_target_group.task.name}"
+}
+
 output "task_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the service role."
   value       = "${aws_iam_role.task.arn}"


### PR DESCRIPTION
Since the Target Group name is randomly generated, it would be useful to have it available as an output.  This value is needed if CodeDeploy is desired for deployment control.