### PR TITLE
Add deployment controller option in service creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,11 @@ resource "aws_ecs_service" "service" {
     container_port   = "${var.task_container_port}"
     target_group_arn = "${aws_lb_target_group.task.arn}"
   }
+
+  deployment_controller {
+    # The deployment controller type to use. Valid values: CODE_DEPLOY, ECS.
+    type = "${var.deployment_controller_type}"
+  }
 }
 
 # HACK: The workaround used in ecs/service does not work for some reason in this module, this fixes the following error:

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,9 @@ variable "deployment_maximum_percent" {
   default     = "200"
   description = "The upper limit of the number of running tasks that can be running in a service during a deployment"
 }
+
+variable "deployment_controller_type" {
+  default     = "ECS"
+  type        = "string"
+  description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS."
+}


### PR DESCRIPTION
In order to support CodeDeploy style deployments, a deployment controller must be specified for "CODE_DEPLOY".  This commit implements the deployment_controller option, and adds a variable, defaulting to "ECS" (the current default).