### PR TITLE
Ignore task/container definition and desired_count changes when using CODE_DEPLOY

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,10 @@ resource "aws_ecs_service" "service" {
     # The deployment controller type to use. Valid values: CODE_DEPLOY, ECS.
     type = "${var.deployment_controller_type}"
   }
+
+  lifecycle {
+    ignore_changes = ["${var.ecs_service_ignored_changes}"]
+  }
 }
 
 # HACK: The workaround used in ecs/service does not work for some reason in this module, this fixes the following error:

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,3 +30,8 @@ output "service_sg_id" {
   description = "The Amazon Resource Name (ARN) that identifies the service security group."
   value       = "${aws_security_group.ecs_service.id}"
 }
+
+output "task_definition_arn" {
+  description = "The ARN of the task definition."
+  value       = "${aws_ecs_task_definition.task.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "task_role_arn" {
 
 output "execution_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the task execution role."
-  value       = "${aws_iam_role.execution}"
+  value       = "${aws_iam_role.execution.arn}"
 }
 
 output "task_role_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 output "service_arn" {
   description = "The Amazon Resource Name (ARN) that identifies the service."
-  value       = "${aws_ecs_service.service.id}"
+  value       = "${element(compact(concat(aws_ecs_service.code_deployed_service.*.id, aws_ecs_service.service.*.id)), 0)}"
 }
 
 output "target_group_arn" {
@@ -38,5 +38,5 @@ output "service_sg_id" {
 
 output "task_definition_arn" {
   description = "The ARN of the task definition."
-  value       = "${aws_ecs_task_definition.task.arn}"
+  value       = "${element(compact(concat(aws_ecs_task_definition.task_for_code_deploy.*.arn, aws_ecs_task_definition.task.*.arn)), 0)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,6 +21,11 @@ output "task_role_arn" {
   value       = "${aws_iam_role.task.arn}"
 }
 
+output "execution_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the task execution role."
+  value       = "${aws_iam_role.execution}"
+}
+
 output "task_role_name" {
   description = "The name of the service role."
   value       = "${aws_iam_role.task.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -106,9 +106,3 @@ variable "deployment_controller_type" {
   type        = "string"
   description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS."
 }
-
-variable "ecs_service_ignored_changes" {
-  type = "list"
-  default = []
-  description = "Any ECS service changes to ignore when updating configuration with terraform"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "deployment_controller_type" {
   type        = "string"
   description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS."
 }
+
+variable "ecs_service_ignored_changes" {
+  type = "list"
+  default = []
+  description = "Any ECS service changes to ignore when updating configuration with terraform"
+}


### PR DESCRIPTION
We are using CODE_DEPLOY to handle deployments for our FARGATE/ECS setup.

When we make changes to other related modules terraform insists on resetting our ECS service back to the desired_count and container_image specified in our variables file.  Really we only needed those to get the service launched in the first place, ensuring we always have those values match reality when we make other changes is tedious, and unnecessary.

This PR makes it automatically ignore those changes if CODE_DEPLOY is specified, however we could add a boolean variable to allow toggling this instead of handling it based off of `deployment_controller_type`.  I just didn't have any use cases where we wouldn't want these particular properties automatically ignored.