### PR TITLE
[WIP] Added lifecycle ignore_changes option to aws_ecs_service resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,11 @@ resource "aws_ecs_service" "service" {
     # The deployment controller type to use. Valid values: CODE_DEPLOY, ECS.
     type = "${var.deployment_controller_type}"
   }
+
+  # Allow external changes by i.e. autoscaler without Terraform plan difference
+  lifecycle {
+    ignore_changes = ["${service_ignore_changes}"]
+  }
 }
 
 # HACK: The workaround used in ecs/service does not work for some reason in this module, this fixes the following error:

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "desired_count" {
   default     = "1"
 }
 
+variable "service_ignore_changes" {
+  description = "Allow external changes to parameters without Terraform plan difference. i.e. desired_count updated by autoscaler."
+  type        = "list"
+  default     = []
+}
+
 variable "task_container_assign_public_ip" {
   description = "Assigned public IP to the container."
   default     = "false"


### PR DESCRIPTION
Problem: desired_count is being updated dynamically by autoscaler. terraform always want to correct it back to what's defined in terraform.

Solution: add lifecycle parameter ignore_changes with "desired_count" in the list to prevent overwriting scaling count. 

*Not yet tested.*