### PR TITLE
Add support for specific container name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [{
-    "name": "${var.name_prefix}",
+    "name": "${var.container_name == "" ? var.name_prefix : var.container_name}",
     "image": "${var.task_container_image}",
     "essential": true,
     "portMappings": [

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ data "null_data_source" "task_environment" {
 }
 
 resource "aws_ecs_task_definition" "task" {
+  id = "${var.name_prefix}"
   family                   = "${var.name_prefix}"
   execution_role_arn       = "${aws_iam_role.execution.arn}"
   network_mode             = "awsvpc"

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [{
-    "name": "${var.override_container_name ? var.container_name : var.name_prefix}",
+    "name": "${var.container_name != "" ? var.container_name : var.name_prefix}",
     "image": "${var.task_container_image}",
     ${local.repository_credentials_rendered}
     "essential": true,
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "service" {
   }
 
   load_balancer {
-    container_name   = "${var.override_container_name ? var.container_name : var.name_prefix}"
+    container_name   = "${var.container_name != "" ? var.container_name : var.name_prefix}"
     container_port   = "${var.task_container_port}"
     target_group_arn = "${aws_lb_target_group.task.arn}"
   }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [{
-    "name": "${var.container_name == "" ? var.name_prefix : var.container_name}",
+    "name": "${var.override_container_name ? var.container_name : var.name_prefix}",
     "image": "${var.task_container_image}",
     ${local.repository_credentials_rendered}
     "essential": true,
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "service" {
   }
 
   load_balancer {
-    container_name   = "${var.container_name == "" ? var.name_prefix : var.container_name}"
+    container_name   = "${var.override_container_name ? var.container_name : var.name_prefix}"
     container_port   = "${var.task_container_port}"
     target_group_arn = "${aws_lb_target_group.task.arn}"
   }

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,6 @@ data "null_data_source" "task_environment" {
 }
 
 resource "aws_ecs_task_definition" "task" {
-  id = "${var.name_prefix}"
   family                   = "${var.name_prefix}"
   execution_role_arn       = "${aws_iam_role.execution.arn}"
   network_mode             = "awsvpc"

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_ecs_service" "service" {
   }
 
   load_balancer {
-    container_name   = "${var.name_prefix}"
+    container_name   = "${var.container_name == "" ? var.name_prefix : var.container_name}"
     container_port   = "${var.task_container_port}"
     target_group_arn = "${aws_lb_target_group.task.arn}"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "service_arn" {
 }
 
 output "service_name" {
-  description = "TThe name of the service."
+  description = "The name of the service."
   value       = "${aws_ecs_service.service.name}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,11 +6,6 @@ output "service_arn" {
   value       = "${aws_ecs_service.service.id}"
 }
 
-output "service_name" {
-  description = "The name of the service."
-  value       = "${aws_ecs_service.service.name}"
-}
-
 output "target_group_arn" {
   description = "The ARN of the Target Group."
   value       = "${aws_lb_target_group.task.arn}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,11 @@ output "service_arn" {
   value       = "${aws_ecs_service.service.id}"
 }
 
+output "service_name" {
+  description = "TThe name of the service."
+  value       = "${aws_ecs_service.service.name}"
+}
+
 output "target_group_arn" {
   description = "The ARN of the Target Group."
   value       = "${aws_lb_target_group.task.arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,13 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
+variable "override_container_name" {
+  description = "True if the container name should be overridden by the value specified in the container_name variable"
+  default = false
+}
+
 variable "container_name" {
-  description = "Optional name for the container. If not specified, name_prefix will be used. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
+  description = "Optional name for the container to be used instead of name_prefix. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,11 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
+variable "container_name" {
+  description = "Optional name for the container. If not specified, name_prefix will be used. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
+  default = ""
+}
+
 variable "vpc_id" {
   description = "The VPC ID."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "name_prefix" {
 
 variable "container_name" {
   description = "Optional name for the container. If not specified, name_prefix will be used. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
-  default = ""
+  default     = ""
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,11 +5,6 @@ variable "name_prefix" {
   description = "A prefix used for naming resources."
 }
 
-variable "override_container_name" {
-  description = "True if the container name should be overridden by the value specified in the container_name variable"
-  default = false
-}
-
 variable "container_name" {
   description = "Optional name for the container to be used instead of name_prefix. Useful when when constructing an imagedefinitons.json file for continuous deployment using Codepipeline."
   default     = ""


### PR DESCRIPTION
Additional optional variable to support a specific container name regardless of prefix value. This is useful/required for utilising the ECS integration option in Codepipeline.