### PR TITLE
Added support for stop timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ resource "aws_ecs_task_definition" "task" {
             "awslogs-stream-prefix": "container"
         }
     },
+    "stopTimeout": ${var.stop_timeout},
     "command": ${jsonencode(var.task_container_command)},
     "environment": ${jsonencode(local.task_environment)}
 }]

--- a/variables.tf
+++ b/variables.tf
@@ -143,3 +143,8 @@ variable "service_registry_arn" {
   description = "ARN of aws_service_discovery_service resource"
   type        = string
 }
+
+variable "stop_timeout" {
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. On Fargate the maximum value is 120 seconds."
+  default     = 30
+}


### PR DESCRIPTION
Enables the user to increase the grace period before hard kill from 30 seconds up to a maximum of 120 seconds on Fargate.