### PR TITLE
Add support for no load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,14 +180,12 @@ resource "aws_ecs_service" "service" {
     assign_public_ip = var.task_container_assign_public_ip
   }
 
-  dynamic "load_balancers" {
+  dynamic "load_balancer" {
     for_each = var.lb_arn == "" ? [] : [1]
     content {
-      load_balancer {
-        container_name   = var.container_name != "" ? var.container_name : var.name_prefix
-        container_port   = var.task_container_port
-        target_group_arn = aws_lb_target_group.task.arn
-      }
+      container_name   = var.container_name != "" ? var.container_name : var.name_prefix
+      container_port   = var.task_container_port
+      target_group_arn = aws_lb_target_group.task.arn
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,7 @@ variable "task_container_image" {
 }
 
 variable "lb_arn" {
+  default     = ""
   description = "Arn for the LB for which the service should be attach to."
   type        = string
 }


### PR DESCRIPTION
I want to add support for services without load balancers.

This solution will still add target groups, but not attach load balancers to the service.