### PR TITLE
Added support for multiple target groups with ECS service and expose …

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,19 +6,9 @@ output "service_arn" {
   value       = aws_ecs_service.service.id
 }
 
-# output "target_group_arn" {
-#   description = "The ARN of the Target Group."
-#   value       = aws_lb_target_group.task.arn
-# }
-
-# output "target_group_name" {
-#   description = "The Name of the Target Group."
-#   value       = aws_lb_target_group.task.name
-# }
-
 output "target_groups" {
   description = "All Target Groups."
-  value = zipmap(aws_lb_target_group.task.*.port, aws_lb_target_group.task.*.arn)
+  value       = zipmap(values(aws_lb_target_group.task)[*]["port"], values(aws_lb_target_group.task)[*]["arn"])
 }
 
 output "task_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,14 +6,19 @@ output "service_arn" {
   value       = aws_ecs_service.service.id
 }
 
-output "target_group_arn" {
-  description = "The ARN of the Target Group."
-  value       = aws_lb_target_group.task.arn
-}
+# output "target_group_arn" {
+#   description = "The ARN of the Target Group."
+#   value       = aws_lb_target_group.task.arn
+# }
 
-output "target_group_name" {
-  description = "The Name of the Target Group."
-  value       = aws_lb_target_group.task.name
+# output "target_group_name" {
+#   description = "The Name of the Target Group."
+#   value       = aws_lb_target_group.task.name
+# }
+
+output "target_groups" {
+  description = "All Target Groups."
+  value = zipmap(aws_lb_target_group.task.*.port, aws_lb_target_group.task.*.arn)
 }
 
 output "task_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,16 +50,28 @@ variable "task_container_assign_public_ip" {
   type        = bool
 }
 
-variable "task_container_port" {
-  description = "Port that the container exposes."
-  type        = number
+# variable "task_container_port" {
+#   description = "Port that the container exposes."
+#   type        = number
+# }
+
+variable "task_container_port_protocol" {
+  description = "The port and protocol mapping passed to a container. Empty list is NOT allowed"
+  type = list(object({
+    containerPort = number
+    hostPort = number
+    protocol = string # The protocol the load balancer uses when routing traffic to the targets. Should be one of TCP/TLS/UDP/TCP_UDP/HTTP/HTTPS
+    health_check_path = string
+    health_check_matcher = string
+    health_check_timeout = number
+  }))
 }
 
-variable "task_container_protocol" {
-  description = "Protocol that the container exposes."
-  default     = "HTTP"
-  type        = string
-}
+# variable "task_container_protocol" {
+#   description = "Protocol that the container exposes."
+#   default     = "HTTP"
+#   type        = string
+# }
 
 variable "task_definition_cpu" {
   description = "Amount of CPU to reserve for the task."
@@ -91,10 +103,10 @@ variable "log_retention_in_days" {
   type        = number
 }
 
-variable "health_check" {
-  description = "A health block containing health check settings for the target group. Overrides the defaults."
-  type        = map(string)
-}
+# variable "health_check" {
+#   description = "A health block containing health check settings for the target group. Overrides the defaults."
+#   type        = map(string)
+# }
 
 variable "health_check_grace_period_seconds" {
   default     = 300

--- a/variables.tf
+++ b/variables.tf
@@ -50,28 +50,33 @@ variable "task_container_assign_public_ip" {
   type        = bool
 }
 
-# variable "task_container_port" {
-#   description = "Port that the container exposes."
-#   type        = number
-# }
-
 variable "task_container_port_protocol" {
-  description = "The port and protocol mapping passed to a container. Empty list is NOT allowed"
-  type = list(object({
-    containerPort = number
-    hostPort = number
-    protocol = string # The protocol the load balancer uses when routing traffic to the targets. Should be one of TCP/TLS/UDP/TCP_UDP/HTTP/HTTPS
-    health_check_path = string
+  description = "The port and protocol mapping passed to a container and taget group with health check."
+  type = map(object({
+    containerPort        = number
+    hostPort             = number
+    protocol             = string # The protocol the load balancer uses when routing traffic to the targets. Should be one of TCP/TLS/UDP/TCP_UDP/HTTP/HTTPS
+    health_check_path    = string
     health_check_matcher = string
     health_check_timeout = number
+    healthy_threshold    = number
+    unhealthy_threshold  = number
+    interval             = number
   }))
+  default = {
+    "80" = {
+      containerPort        = 80
+      hostPort             = 80
+      protocol             = "HTTP"
+      health_check_path    = "/"
+      health_check_matcher = "200"
+      health_check_timeout = 4
+      healthy_threshold    = 2
+      unhealthy_threshold  = 2
+      interval             = 5
+    }
+  }
 }
-
-# variable "task_container_protocol" {
-#   description = "Protocol that the container exposes."
-#   default     = "HTTP"
-#   type        = string
-# }
 
 variable "task_definition_cpu" {
   description = "Amount of CPU to reserve for the task."


### PR DESCRIPTION
- Added support for multiple targe groups with ECS service based on this feature: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html
- Added support for exposing multiple ports in same container from Task
- Remove the support for single port and protocol variables