### PR TITLE
Add: Secret injection from Secrets Manager. 

### DIFF
--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,0 +1,3 @@
+## examples/basic
+
+An example which shows _basic_ usage of the module.

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,3 +1,3 @@
-## examples/basic
+## examples/secrets
 
-An example which shows _basic_ usage of the module.
+An example which shows how to inject secrets with of the module.

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -1,0 +1,129 @@
+# ----------------------------------------
+# Create a ecs service using fargate
+# ----------------------------------------
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  version = ">= 2.17"
+  region  = var.region
+}
+
+data "aws_vpc" "main" {
+  default = true
+}
+
+data "aws_subnet_ids" "main" {
+  vpc_id = data.aws_vpc.main.id
+}
+
+
+module "fargate_alb" {
+  source  = "telia-oss/loadbalancer/aws"
+  version = "3.0.0"
+
+  name_prefix = var.name_prefix
+  type        = "application"
+  internal    = false
+  vpc_id      = data.aws_vpc.main.id
+  subnet_ids  = data.aws_subnet_ids.main.ids
+
+  tags = {
+    environment = "dev"
+    terraform   = "True"
+  }
+}
+
+resource "aws_lb_listener" "alb" {
+  load_balancer_arn = module.fargate_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = module.fargate.target_group_arn
+    type             = "forward"
+  }
+}
+
+resource "aws_security_group_rule" "task_ingress_8000" {
+  security_group_id        = module.fargate.service_sg_id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 8000
+  to_port                  = 8000
+  source_security_group_id = module.fargate_alb.security_group_id
+}
+
+resource "aws_security_group_rule" "alb_ingress_80" {
+  security_group_id = module.fargate_alb.security_group_id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+resource "aws_ecs_cluster" "cluster" {
+  name = "${var.name_prefix}-cluster"
+}
+
+resource "aws_secretsmanager_secret" "task_secrets" {
+  name       = var.name_prefix
+  kms_key_id = var.task_secrets_kms_key
+}
+
+resource "aws_secretsmanager_secret_version" "task_secrets" {
+  secret_id     = aws_secretsmanager_secret.task_secrets.id
+  secret_string = "Super secret and important string"
+}
+
+data "aws_secretsmanager_secret" "task_secrets" {
+  arn = aws_secretsmanager_secret.task_secrets.arn
+}
+
+data "aws_kms_key" "task_secrets" {
+  key_id = data.aws_secretsmanager_secret.task_secrets.kms_key_id
+}
+
+module "fargate" {
+  source = "../../"
+
+  name_prefix          = var.name_prefix
+  vpc_id               = data.aws_vpc.main.id
+  private_subnet_ids   = data.aws_subnet_ids.main.ids
+  lb_arn               = module.fargate_alb.arn
+  cluster_id           = aws_ecs_cluster.cluster.id
+  task_container_image = "crccheck/hello-world:latest"
+
+  // public ip is needed for default vpc, default is false
+  task_container_assign_public_ip = true
+
+  // port, default protocol is HTTP
+  task_container_port = 8000
+
+  task_container_environment = {
+    TEST_VARIABLE = "TEST_VALUE"
+  }
+
+  task_secrets_kms_key = data.aws_kms_key.task_secrets.key_id
+
+  task_secrets = [
+    {
+      name      = "TASK_SECRET"
+      valueFrom = aws_secretsmanager_secret_version.task_secrets.arn
+    }
+  ]
+
+  health_check = {
+    port = "traffic-port"
+    path = "/"
+  }
+
+  tags = {
+    environment = "dev"
+    terraform   = "True"
+  }
+}
+

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -69,22 +69,22 @@ resource "aws_ecs_cluster" "cluster" {
   name = "${var.name_prefix}-cluster"
 }
 
-resource "aws_secretsmanager_secret" "task_secrets" {
+resource "aws_secretsmanager_secret" "task_container_secrets" {
   name       = var.name_prefix
-  kms_key_id = var.task_secrets_kms_key
+  kms_key_id = var.task_container_secrets_kms_key
 }
 
-resource "aws_secretsmanager_secret_version" "task_secrets" {
-  secret_id     = aws_secretsmanager_secret.task_secrets.id
+resource "aws_secretsmanager_secret_version" "task_container_secrets" {
+  secret_id     = aws_secretsmanager_secret.task_container_secrets.id
   secret_string = "Super secret and important string"
 }
 
-data "aws_secretsmanager_secret" "task_secrets" {
-  arn = aws_secretsmanager_secret.task_secrets.arn
+data "aws_secretsmanager_secret" "task_container_secrets" {
+  arn = aws_secretsmanager_secret.task_container_secrets.arn
 }
 
-data "aws_kms_key" "task_secrets" {
-  key_id = data.aws_secretsmanager_secret.task_secrets.kms_key_id
+data "aws_kms_key" "task_container_secrets" {
+  key_id = data.aws_secretsmanager_secret.task_container_secrets.kms_key_id
 }
 
 module "fargate" {
@@ -107,12 +107,12 @@ module "fargate" {
     TEST_VARIABLE = "TEST_VALUE"
   }
 
-  task_secrets_kms_key = data.aws_kms_key.task_secrets.key_id
+  task_container_secrets_kms_key = data.aws_kms_key.task_container_secrets.key_id
 
-  task_secrets = [
+  task_container_secrets = [
     {
       name      = "TASK_SECRET"
-      valueFrom = aws_secretsmanager_secret_version.task_secrets.arn
+      valueFrom = aws_secretsmanager_secret_version.task_container_secrets.arn
     }
   ]
 
@@ -126,4 +126,3 @@ module "fargate" {
     terraform   = "True"
   }
 }
-

--- a/examples/secrets/outputs.tf
+++ b/examples/secrets/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_arn" {
+  value = aws_ecs_cluster.cluster.arn
+}
+
+output "service_arn" {
+  value = module.fargate.service_arn
+}
+
+output "endpoint" {
+  value = module.fargate_alb.dns_name
+}

--- a/examples/secrets/variables.tf
+++ b/examples/secrets/variables.tf
@@ -1,0 +1,15 @@
+variable "name_prefix" {
+  type    = string
+  default = "fargate-task-secrets-example"
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-1"
+}
+
+variable "task_secrets_kms_key" {
+  type        = string
+  description = ""
+  default     = "alias/aws/secretsmanager"
+}

--- a/examples/secrets/variables.tf
+++ b/examples/secrets/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
   default = "eu-west-1"
 }
 
-variable "task_secrets_kms_key" {
+variable "task_container_secrets_kms_key" {
   type        = string
   description = ""
   default     = "alias/aws/secretsmanager"

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,9 @@ resource "aws_ecs_task_definition" "task" {
         "credentialsParameter": "${var.repository_credentials}"
     },
     %{~endif}
+    %{if length(var.task_secrets) > 0~}
+    "secrets": ${jsonencode(var.task_secrets)},
+    %{~endif}
     "essential": true,
     "portMappings": [
         {

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,12 @@ resource "aws_iam_role_policy" "read_repository_credentials" {
   policy = data.aws_iam_policy_document.read_repository_credentials.json
 }
 
+resource "aws_iam_role_policy" "read_task_secret_key" {
+  name   = "${var.name_prefix}-read-task-secrets-key"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.task_secrets.json
+}
+
 # ------------------------------------------------------------------------------
 # IAM - Task role, basic. Users of the module will append policies to this role
 # when they use the module. S3, Dynamo permissions etc etc.

--- a/main.tf
+++ b/main.tf
@@ -33,10 +33,10 @@ resource "aws_iam_role_policy" "read_repository_credentials" {
   policy = data.aws_iam_policy_document.read_repository_credentials.json
 }
 
-resource "aws_iam_role_policy" "read_task_secret_key" {
-  name   = "${var.name_prefix}-read-task-secrets-key"
+resource "aws_iam_role_policy" "read_task_container_secrets" {
+  name   = "${var.name_prefix}-read-task-container-secrets"
   role   = aws_iam_role.execution.id
-  policy = data.aws_iam_policy_document.task_secrets.json
+  policy = data.aws_iam_policy_document.task_container_secrets.json
 }
 
 # ------------------------------------------------------------------------------
@@ -147,8 +147,8 @@ resource "aws_ecs_task_definition" "task" {
         "credentialsParameter": "${var.repository_credentials}"
     },
     %{~endif}
-    %{if length(var.task_secrets) > 0~}
-    "secrets": ${jsonencode(var.task_secrets)},
+    %{if length(var.task_container_secrets) > 0~}
+    "secrets": ${jsonencode(var.task_container_secrets)},
     %{~endif}
     "essential": true,
     "portMappings": [

--- a/policies.tf
+++ b/policies.tf
@@ -86,10 +86,3 @@ data "aws_iam_policy_document" "task_secrets" {
   }
 }
 
-resource "aws_iam_role_policy" "read_task_secret_key" {
-  name   = "${var.name_prefix}-read-task-secrets-key"
-  role   = aws_iam_role.execution.id
-  policy = data.aws_iam_policy_document.task_secrets.json
-}
-
-

--- a/policies.tf
+++ b/policies.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "task_secrets" {
 
 resource "aws_iam_role_policy" "read_task_secret_key" {
   name   = "${var.name_prefix}-read-task-secrets-key"
-  role   = aws_iam_role.task.id
+  role   = aws_iam_role.execution.id
   policy = data.aws_iam_policy_document.task_secrets.json
 }
 

--- a/policies.tf
+++ b/policies.tf
@@ -67,17 +67,17 @@ data "aws_iam_policy_document" "read_repository_credentials" {
   }
 }
 
-data "aws_kms_key" "task_secrets_key" {
-  key_id = var.task_secrets_kms_key
+data "aws_kms_key" "task_container_secrets_key" {
+  key_id = var.task_container_secrets_kms_key
 }
 
-data "aws_iam_policy_document" "task_secrets" {
+data "aws_iam_policy_document" "task_container_secrets" {
   statement {
     effect = "Allow"
 
     resources = concat(
-      [data.aws_kms_key.task_secrets_key.arn],
-      [for i in var.task_secrets : i["valueFrom"]]
+      [data.aws_kms_key.task_container_secrets_key.arn],
+      [for i in var.task_container_secrets : i["valueFrom"]]
     )
     actions = [
       "secretsmanager:GetSecretValue",

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -39,6 +39,27 @@ func TestModule(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "task secrets example",
+			directory:   "../examples/secrets",
+			name:        fmt.Sprintf("fargate-secrets-test-%s", random.UniqueId()),
+			region:      "eu-west-1",
+			expected: ecs.Expectations{
+				DesiredTaskCount: 1,
+				TaskCPU:          256,
+				TaskMemory:       512,
+				NetworkMode:      "awsvpc",
+				ContainerImage:   "crccheck/hello-world:latest",
+				ContainerEnvironment: map[string]string{
+					"TEST_VARIABLE": "TEST_VALUE",
+				},
+				HTTPGetResponse: []string{
+					`Hello World`,
+					`~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~`,
+					`\______ o          _,/`,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,17 @@ variable "container_name" {
   type        = string
 }
 
+variable "task_secrets" {
+  type    = list(object({ name = string, valueFrom = string }))
+  default = []
+}
+
+variable "task_secrets_kms_key" {
+  type        = string
+  description = ""
+  default     = "alias/aws/secretsmanager"
+}
+
 variable "vpc_id" {
   description = "The VPC ID."
   type        = string
@@ -132,6 +143,7 @@ variable "repository_credentials" {
   description = "name or ARN of a secrets manager secret (arn:aws:secretsmanager:region:aws_account_id:secret:secret_name)"
   type        = string
 }
+
 
 variable "repository_credentials_kms_key" {
   default     = "alias/aws/secretsmanager"

--- a/variables.tf
+++ b/variables.tf
@@ -12,12 +12,12 @@ variable "container_name" {
   type        = string
 }
 
-variable "task_secrets" {
+variable "task_container_secrets" {
   type    = list(object({ name = string, valueFrom = string }))
   default = []
 }
 
-variable "task_secrets_kms_key" {
+variable "task_container_secrets_kms_key" {
   type        = string
   description = ""
   default     = "alias/aws/secretsmanager"


### PR DESCRIPTION
This PR adds the possibility to inject secrets to a task, this should allow a user to not have to commit a secret to the terraform state if they do not wish do to so.

We use this to inject our internal CA key to a running CFSSL container on Fargate for internal machine certificates without having it be part of the terraform state nor part of the container image at build time. 

Sidenote: We found that when using multi line secrets in secrets manager, base64 encoding them before and decoding a startup was the easiest way to make sure formatting was intact as SM can screw with you there.