### PR TITLE
removing port assignment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ resource "aws_ecs_service" "service" {
     for_each = var.service_registry_arn == "" ? [] : [1]
     content {
       registry_arn   = var.service_registry_arn
-      container_port = var.task_container_port
+      // container_port = var.task_container_port
       container_name = var.container_name != "" ? var.container_name : var.name_prefix
     }
   }


### PR DESCRIPTION
Not sure how we would want to solve this however, since the task-definition is hard set to network type of 'awsvpc', the service registry definitions will not take both containerPort and containerName. Only one is to be specified with this type.

We could however on the contrary, extent the module to support network type bridge. On bridge mode, both those vars are needed.

Opening PR as this works like this however, if we want to do the rest of the extension for the module more work will need to be committed. 


link to aws documentation https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceRegistry.html