### PR TITLE
Avoid breaking permissions by accidental provider upgrade

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,9 @@
 terraform {
   required_version = ">= 0.12"
-}
 
-provider "aws" { version = ">= 2.0.0, < 3.0.0" }
+  required_providers {
+    aws = {
+      version = ">= 2.0.0, < 3.0.0"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
-
 terraform {
   required_version = ">= 0.12"
 }
+
+provider "aws" { version = ">= 2.0.0, < 3.0.0" }


### PR DESCRIPTION
Partial fix for #39 .

This will prevent accidentally breaking your permissions when you upgrade to v3 aws provider.

Next PR will include minimum version requirement of v3 and contain a code fix.