### PR TITLE
Require v3 provider and be backwards compatible with v2 provider

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "task_permissions" {
     effect = "Allow"
 
     resources = [
-      aws_cloudwatch_log_group.main.arn,
+      "${aws_cloudwatch_log_group.main.arn}:*",
     ]
 
     actions = [

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 2.0.0, < 3.0.0"
+      version = ">= 3.0.0"
     }
   }
 }


### PR DESCRIPTION
Fixes #39.

Require aws provider v3.

This will keep the permissions like they was with the v2 aws provider and will not give any change in plan output.