### PR TITLE
Add conditional container_port for service registry for A records

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ resource "aws_ecs_service" "service" {
     for_each = var.service_registry_arn == "" ? [] : [1]
     content {
       registry_arn   = var.service_registry_arn
-      container_port = var.task_container_port
+      container_port = var.with_service_discovery_srv_record ? var.task_container_port : null
       container_name = var.container_name != "" ? var.container_name : var.name_prefix
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,6 @@ variable "repository_credentials" {
   type        = string
 }
 
-
 variable "repository_credentials_kms_key" {
   default     = "alias/aws/secretsmanager"
   description = "key id, key ARN, alias name or alias ARN of the key that encrypted the repository credentials"
@@ -155,6 +154,12 @@ variable "service_registry_arn" {
   default     = ""
   description = "ARN of aws_service_discovery_service resource"
   type        = string
+}
+
+variable "service_discovery_srv_record" {
+  default     = true
+  type        = bool
+  description = "Set to false if you specify a SRV DNS record in aws_service_discovery_service. If only A record, set this to false."
 }
 
 variable "stop_timeout" {


### PR DESCRIPTION
Fixes issue where no SRV record in service disvocery dns config
causes the service_registries block in the aws_ecs_service resource
to fail because it does not accept container_port parameter.