### PR TITLE
Add name to lb target group to improve Console readability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,8 @@ resource "aws_security_group_rule" "egress_service" {
 # LB Target group
 # ------------------------------------------------------------------------------
 resource "aws_lb_target_group" "task" {
+  name = "${var.name_prefix}-${var.task_container_port}"
+
   vpc_id      = var.vpc_id
   protocol    = var.task_container_protocol
   port        = var.task_container_port


### PR DESCRIPTION
LB target group names currently look like this: `tf-20200527122359653400000001` and don't show the Name tag contents in the name field. This makes looking up a service related target group very hard unless you search for the tag name. This PR adds the name to it.

Changing the name forces a new resource.