### PR TITLE
feat: add support for log multiline pattern

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,9 @@ resource "aws_ecs_task_definition" "task" {
         "options": {
             "awslogs-group": "${aws_cloudwatch_log_group.main.name}",
             "awslogs-region": "${data.aws_region.current.name}",
+            %{if var.log_multiline_pattern != ""~}
+            "awslogs-multiline-pattern": "${var.log_multiline_pattern}",
+            %{~endif}
             "awslogs-stream-prefix": "container"
         }
     },

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "log_retention_in_days" {
   type        = number
 }
 
+variable "log_multiline_pattern" {
+  description = "Optional regular expression. Log messages will consist of a line that matches expression and any following lines that don't"
+  default     = ""
+  type        = string
+}
+
 variable "health_check" {
   description = "A health block containing health check settings for the target group. Overrides the defaults."
   type        = map(string)


### PR DESCRIPTION
Add support for [aws logs multiline pattern](https://docs.docker.com/config/containers/logging/awslogs/#awslogs-multiline-pattern) in the log configuration option of the container definition.

A new optional variable has been added, being this change completely backwards compatible.