### PR TITLE
Add variable to configure permissions boundary on IAM roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,9 @@ resource "aws_cloudwatch_log_group" "main" {
 # IAM - Task execution role, needed to pull ECR images etc.
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "execution" {
-  name               = "${var.name_prefix}-task-execution-role"
-  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+  name                 = "${var.name_prefix}-task-execution-role"
+  assume_role_policy   = data.aws_iam_policy_document.task_assume.json
+  permissions_boundary = var.task_role_permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "task_execution" {
@@ -44,8 +45,9 @@ resource "aws_iam_role_policy" "read_task_container_secrets" {
 # when they use the module. S3, Dynamo permissions etc etc.
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "task" {
-  name               = "${var.name_prefix}-task-role"
-  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+  name                 = "${var.name_prefix}-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.task_assume.json
+  permissions_boundary = var.task_role_permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "log_agent" {

--- a/variables.tf
+++ b/variables.tf
@@ -166,3 +166,9 @@ variable "stop_timeout" {
   description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. On Fargate the maximum value is 120 seconds."
   default     = 30
 }
+
+variable "task_role_permissions_boundary_arn" {
+  description = "ARN of the policy that is used to set the permissions boundary for the task (and task execution) role."
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
As per the title, it would be nice to be able to set a permission boundary on the roles created within the module (for those who have not switched to SCPs) 😅 This is based on a change that @colincoleman has already [added to a fork](https://github.com/Cantara/terraform-aws-ecs-fargate/commit/e2628533a605cefb4cfe04e081ab31cf9135d5cc) and I figured we might go in the upstream also.

This should not be a breaking change for existing deployments, so it can be a minor version (feature) bump.