### PR TITLE
Service depends on the task execution policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -168,6 +168,9 @@ resource "aws_ecs_service" "service" {
   depends_on = [
     null_resource.lb_exists,
     aws_iam_role_policy.task_execution,
+    aws_iam_role_policy.log_agent,
+    aws_iam_role_policy.read_repository_credentials,
+    aws_iam_role_policy.read_task_container_secrets,
   ]
   name                               = var.name_prefix
   cluster                            = var.cluster_id

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ resource "aws_ecs_task_definition" "task" {
 }
 
 resource "aws_ecs_service" "service" {
-  depends_on                         = [
+  depends_on = [
     null_resource.lb_exists,
     aws_iam_role_policy.task_execution,
   ]

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,10 @@ resource "aws_ecs_task_definition" "task" {
 }
 
 resource "aws_ecs_service" "service" {
-  depends_on                         = [null_resource.lb_exists]
+  depends_on                         = [
+    null_resource.lb_exists,
+    aws_iam_role_policy.task_execution,
+  ]
   name                               = var.name_prefix
   cluster                            = var.cluster_id
   task_definition                    = aws_ecs_task_definition.task.arn


### PR DESCRIPTION
Fixes this error message from the ECS console under Events:
`
service X failed to launch a task with (error ECS was unable to assume the role 'arn:aws:iam::<account_id>:role/X-task-execution-role' that was provided for this task. Please verify that the role being passed has the proper trust relationship and permissions and that your IAM user has permissions to pass this role.).
`

And this one:
`service X failed to launch a task with (error ECS was unable to assume the role X that was provided for this task. Please verify that the role being passed has the proper trust relationship and permissions and that your IAM user has permissions to pass this role.).
`