### PR TITLE
Add possibility to customize roles name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_log_group" "main" {
 # IAM - Task execution role, needed to pull ECR images etc.
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "execution" {
-  name                 = "${var.name_prefix}-task-execution-role"
+  name                 = "${var.name_prefix}${var.aws_iam_role_execution_suffix}"
   assume_role_policy   = data.aws_iam_policy_document.task_assume.json
   permissions_boundary = var.task_role_permissions_boundary_arn
 }
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy" "read_task_container_secrets" {
 # when they use the module. S3, Dynamo permissions etc etc.
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "task" {
-  name                 = "${var.name_prefix}-task-role"
+  name                 = "${var.name_prefix}${var.aws_iam_role_task_suffix}"
   assume_role_policy   = data.aws_iam_policy_document.task_assume.json
   permissions_boundary = var.task_role_permissions_boundary_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -207,3 +207,16 @@ variable "deployment_circuit_breaker" {
   type        = object({ enable = bool, rollback = bool })
   default     = { enable = false, rollback = false }
 }
+
+
+variable "aws_iam_role_execution_suffix" {
+  description = "Name suffix for task execution IAM role"
+  type        = string
+  default     = "-task-execution-role"
+}
+
+variable "aws_iam_role_task_suffix" {
+  description = "Name suffix for task IAM role"
+  type        = string
+  default     = "-task-role"
+}


### PR DESCRIPTION
Due to the AWS role name length limitation, it could be useful to be able to customize role suffix to shorten it for exemple