### PR TITLE
Possibility to set readonlyRootFilesystem on container.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ locals {
       "options"   = local.log_configuration_options
     }
     "privileged" : var.privileged
+    "readonlyRootFilesystem" : var.readonlyRootFilesystem
   }, local.task_container_secrets, local.repository_credentials)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -223,6 +223,12 @@ variable "privileged" {
   type        = bool
 }
 
+variable "readonlyRootFilesystem" {
+  description = "When this parameter is true, the container is given read-only access to its root file system."
+  default     = false
+  type        = bool
+}
+
 variable "wait_for_steady_state" {
   description = "Wait for the service to reach a steady state (like aws ecs wait services-stable) before continuing."
   type        = bool


### PR DESCRIPTION
AWS Foundational Security Best Practices [ECS.5] ECS containers should be limited to read-only access to root filesystems