### PR TITLE
Change variable type to allow multiple objects

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -284,7 +284,7 @@ variable "enable_execute_command" {
 
 variable "sidecar_containers" {
   description = "List of sidecar containers"
-  type        = list(any)
+  type        = list(object({}))
   default     = []
 }
 


### PR DESCRIPTION
Getting error:

`Error: Invalid value for input variable ... all list elements must have the same type.`