### PR TITLE
Less strict sidecar container definition type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -284,7 +284,7 @@ variable "enable_execute_command" {
 
 variable "sidecar_containers" {
   description = "List of sidecar containers"
-  type        = list(any)
+  type        = any
   default     = []
 }
 


### PR DESCRIPTION
Getting error:

`Error: Invalid value for input variable ... all list elements must have the same type.` when the list of container definitions doesnt have exactly the same keys in the map.

An alternative is to declare the whole container definition type using `object({ ... })`, but its a bit tedious to maintain.