### PR TITLE
Updating null provider version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.1.0"
+      version = "~> 3.2.1"
     }
   }
 }


### PR DESCRIPTION
- The provider version constraint needs to be updated to 3.2 or higher because versions below 3.2 are no longer available for download when using terraform init.

- To resolve the issue, update the provider version constraint to 3.2 or later, as versions prior to 3.2 are no longer downloadable via terraform init.

- Terraform init cannot download provider versions below 3.2, so it is necessary to update the provider version constraint to 3.2 or higher.

- Terraform gives the following: 

"Error: Failed to query available provider packages. Could not retrieve the list of available versions for provider hashicorp/null: no available releases match the given constraints ~> 3.1.0"

Note: My terraform version is 1.5.7