### PR TITLE
Allow higher versions of null provider

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 env:
   TERM: screen-256color
@@ -36,7 +36,7 @@ tasks:
 
       CWD=$PWD
 
-      for d in $DIRECTORIES; do 
+      for d in $DIRECTORIES; do
         cd $d
         echo "${BOLD}$PWD:${NORM}"
 
@@ -66,4 +66,4 @@ tasks:
     silent: true
     cmds:
     - go test -v ./... -timeout=1h
-    
+

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.1.0"
+      version = ">= 3.1.0"
     }
   }
 }


### PR DESCRIPTION
Allows higher versions of the null provider.

null 3.2.2 has some bug and upstream security fixes, so this should ideally probably be `~> 3.2.2`

3.2.2 should be functionally identical to 3.1.0

Also bumps Taskfile schema version. 