### PR TITLE
Add support to set ephemeral storage for task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,6 +196,11 @@ resource "aws_ecs_task_definition" "task" {
       name = volume.value["name"]
     }
   }
+
+  ephemeral_storage {
+    size_in_gib = var.task_ephemeral_storage
+  }
+
   container_definitions = jsonencode(concat([local.container_definition], var.sidecar_containers))
   runtime_platform {
     operating_system_family = var.task_definition_os_family

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "task_definition_memory" {
   type        = number
 }
 
+variable "task_ephemeral_storage" {
+  description = "Amount of ephemeral storage (GiB) for the task"
+  default     = 21
+  type        = number
+}
+
 variable "task_definition_os_family" {
   description = "The OS of the container."
   default     = "LINUX"


### PR DESCRIPTION
ECS tasks by default seem to receive 21 GiB of ephemeral storage. This PR adds support to change it up to the supported 200 GiB.

Increased ephemeral storage may fit some use cases better than EFS volumes.