### PR TITLE
add config to select aws logging driver mode and buffer size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,8 @@ locals {
     "awslogs-group"         = var.log_group_name != "" ? var.log_group_name : aws_cloudwatch_log_group.main.0.name,
     "awslogs-region"        = data.aws_region.current.name
     "awslogs-stream-prefix" = "container"
+    "mode"                  = var.aws_log_driver_mode
+    "max-buffer-size"       = var.aws_log_max_buffer_size
   }, local.log_multiline_pattern)
 
   container_definition = merge({

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,18 @@ variable "log_multiline_pattern" {
   type        = string
 }
 
+variable "aws_log_driver_mode" {
+  description = "The log mode option controls whether to use the blocking (default) or non-blocking log delivery"
+  default     = "blocking"
+  type        = string
+}
+
+variable "aws_log_max_buffer_size" {
+  description = "Controls the size of the buffer used for intermediate log message storage when aws_log_driver_mode is set to non-blocking"
+  default     = "1m"
+  type        = string
+}
+
 variable "health_check" {
   description = "A health block containing health check settings for the target group. Overrides the defaults."
   type        = map(string)


### PR DESCRIPTION
Ability to select AWSLogs log driver mode to "non-blocking" and thus prevent applications from termination when logs cannot be immediately sent to Cloudwatch as per https://aws.amazon.com/blogs/containers/preventing-log-loss-with-non-blocking-mode-in-the-awslogs-container-log-driver/
More details from Docker docs: https://docs.docker.com/engine/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver